### PR TITLE
Corrigir posição da assinatura no PDF

### DIFF
--- a/CORRECOES_ASSINATURA_PDF.md
+++ b/CORRECOES_ASSINATURA_PDF.md
@@ -1,0 +1,113 @@
+# Correções Implementadas - Posicionamento de Assinatura PDF
+
+## Problema Identificado
+O sistema de assinatura digital de PDFs estava posicionando as assinaturas fora do local escolhido pelo usuário, especialmente em dispositivos móveis.
+
+## Principais Correções Realizadas
+
+### 1. Correção do Cálculo de Coordenadas no Backend ✅
+**Arquivo:** `api/sign-document.js`
+
+**Problema:** O backend estava **multiplicando** as coordenadas pela escala de renderização quando deveria **dividir**.
+
+**Antes:**
+```javascript
+const finalPdfX = canvasX * frontendRenderScale;
+const finalPdfWidth = canvasWidth * frontendRenderScale;
+const finalPdfHeight = canvasHeight * frontendRenderScale;
+const finalPdfY = pageHeight - (canvasY + canvasHeight) * frontendRenderScale;
+```
+
+**Depois:**
+```javascript
+const finalPdfX = canvasX / frontendRenderScale;
+const finalPdfWidth = canvasWidth / frontendRenderScale;
+const finalPdfHeight = canvasHeight / frontendRenderScale;
+const finalPdfY = pageHeight - (canvasY + canvasHeight) / frontendRenderScale;
+```
+
+### 2. Escala de Renderização Adaptativa ✅
+**Arquivo:** `public/sign.html`
+
+**Implementação:** Sistema de escala dinâmica que se adapta ao tamanho da tela do dispositivo.
+
+```javascript
+// Escala adaptativa para dispositivos móveis
+const isMobile = window.innerWidth <= 768;
+const containerWidth = pdfViewerContainer.clientWidth;
+const baseViewport = page.getViewport({ scale: 1.0 });
+
+// Calcula a escala ideal para caber no container
+const scaleToFit = (containerWidth * 0.9) / baseViewport.width;
+
+// Define escala: menor entre a calculada e valores máximos/mínimos
+const maxScale = isMobile ? 2.0 : 1.5;
+const minScale = 0.8;
+const scale = Math.min(Math.max(scaleToFit, minScale), maxScale);
+```
+
+### 3. Melhorias para Dispositivos Móveis ✅
+**Arquivo:** `public/sign.html`
+
+**Adicionado CSS responsivo:**
+- Elementos de assinatura com tamanho mínimo maior em mobile
+- Redimensionadores maiores para facilitar o toque
+- Botões de exclusão maiores
+- Ghost preview otimizado para mobile
+
+```css
+@media (max-width: 600px) {
+    .signature-element {
+        min-width: 80px;
+        min-height: 40px;
+    }
+    
+    .resizer {
+        width: 15px;
+        height: 15px;
+    }
+    
+    .delete-element-btn, .delete-saved-sig-btn {
+        width: 35px;
+        height: 35px;
+        font-size: 1.2em;
+    }
+}
+```
+
+### 4. Sincronização de Escala ✅
+**Implementação:** Variável global que mantém a escala atual sincronizada entre renderização e envio.
+
+```javascript
+let currentRenderScale = 1.5; // Escala dinâmica global
+
+// Na renderPage()
+currentRenderScale = scale;
+
+// No envio da assinatura
+renderScale: Number(currentRenderScale)
+```
+
+## Benefícios das Correções
+
+1. **Posicionamento Preciso:** As assinaturas agora aparecem exatamente onde o usuário as posicionou
+2. **Compatibilidade Mobile:** Melhor experiência em dispositivos móveis com escala adaptativa
+3. **Responsividade:** Interface se adapta automaticamente ao tamanho da tela
+4. **Usabilidade Aprimorada:** Elementos maiores e mais fáceis de tocar em mobile
+
+## Como Testar
+
+1. **Desktop:** Teste o posicionamento em diferentes tamanhos de janela
+2. **Mobile:** Teste em dispositivos com diferentes resoluções
+3. **Diferentes PDFs:** Teste com documentos de tamanhos variados
+4. **Múltiplas Assinaturas:** Adicione várias assinaturas no mesmo documento
+
+## Logs de Debug
+
+O sistema inclui logs detalhados para diagnóstico:
+- Coordenadas originais do frontend
+- Escala de renderização calculada
+- Coordenadas finais convertidas para o PDF
+- Informações de dispositivo mobile
+
+Estes logs aparecem no console do navegador e nos logs do servidor para facilitar o debugging futuro.

--- a/api/sign-document.js
+++ b/api/sign-document.js
@@ -217,17 +217,17 @@ export default async function handler(req, res) {
     const frontendRenderScale = req.body.renderScale; // ou req.body.frontendRenderScale
 
     // Converte as coordenadas e dimensões de PIXELS do canvas do frontend para PONTOS do PDF original.
-    // Coordenada X: simples divisão pela escala.
-    const finalPdfX = canvasX * frontendRenderScale;
-    const finalPdfWidth = canvasWidth * frontendRenderScale;
-    const finalPdfHeight = canvasHeight * frontendRenderScale;
+    // Coordenada X: divisão pela escala para converter pixels escalados de volta para pontos originais.
+    const finalPdfX = canvasX / frontendRenderScale;
+    const finalPdfWidth = canvasWidth / frontendRenderScale;
+    const finalPdfHeight = canvasHeight / frontendRenderScale;
 
     // Coordenada Y:
     // O frontend (canvas) mede Y a partir do topo da página (top-left origin).
     // O pdf-lib mede Y a partir da BASE da página (bottom-left origin).
     // Para converter: (Altura REAL da página PDF em pontos) - (coordenada Y do topo em pixels / escala + altura do elemento em pixels / escala)
     const finalPdfY =
-      pageHeight - (canvasY + canvasHeight) * frontendRenderScale;
+      pageHeight - (canvasY + canvasHeight) / frontendRenderScale;
 
     console.log(
       "Backend - Coordenadas originais do frontend (em pixels do canvas):",

--- a/public/sign.html
+++ b/public/sign.html
@@ -211,6 +211,29 @@
                 --toolbar-height: 120px; /* Aumenta a altura da toolbar em telas menores */
                 --controls-height: 120px; /* Aumenta a altura dos controles em telas menores */
             }
+            
+            /* Melhora a usabilidade em mobile */
+            .signature-element {
+                min-width: 80px; /* Tamanho mínimo maior para facilitar o toque */
+                min-height: 40px;
+            }
+            
+            .resizer {
+                width: 15px; /* Redimensionadores maiores para mobile */
+                height: 15px;
+            }
+            
+            .delete-element-btn, .delete-saved-sig-btn {
+                width: 35px; /* Botões de exclusão maiores para mobile */
+                height: 35px;
+                font-size: 1.2em;
+            }
+            
+            /* Ghost preview ligeiramente maior em mobile */
+            #ghost-signature-preview {
+                min-width: 100px;
+                min-height: 50px;
+            }
         }
 
 
@@ -573,6 +596,7 @@
         let isPlacingSignature = false; 
         let selectedElement = null; 
         let selectedSavedSignatureId = null; // Para gerenciar assinaturas salvas
+        let currentRenderScale = 1.5; // Escala de renderização atual, atualizada dinamicamente
 
 
         backToListBtn.addEventListener('click', () => {
@@ -678,7 +702,25 @@
 
             currentPage = pageNum;
             const page = await pdfDoc.getPage(pageNum);
-            const scale = 1.5; 
+            
+            // Escala adaptativa para dispositivos móveis
+            const isMobile = window.innerWidth <= 768;
+            const containerWidth = pdfViewerContainer.clientWidth;
+            const baseViewport = page.getViewport({ scale: 1.0 });
+            
+            // Calcula a escala ideal para caber no container
+            const scaleToFit = (containerWidth * 0.9) / baseViewport.width;
+            
+            // Define escala: menor entre a calculada e valores máximos/mínimos
+            const maxScale = isMobile ? 2.0 : 1.5;
+            const minScale = 0.8;
+            const scale = Math.min(Math.max(scaleToFit, minScale), maxScale);
+            
+            console.log(`Renderizando página ${pageNum} - isMobile: ${isMobile}, containerWidth: ${containerWidth}, scaleToFit: ${scaleToFit.toFixed(2)}, scale final: ${scale.toFixed(2)}`);
+            
+            // Armazena a escala atual para usar no envio da assinatura
+            currentRenderScale = scale;
+            
             const viewport = page.getViewport({ scale: scale }); 
 
             pdfCanvas.height = viewport.height;
@@ -1431,7 +1473,7 @@
 
                 // --- INÍCIO DA ALTERAÇÃO NO FRONTEND ---
                 // Enviando as coordenadas do elemento em PIXELS (do canvas) para o backend
-                const scale = 1.5; // Use o mesmo valor usado em renderPage
+                // Usa a escala atual calculada dinamicamente
                 
                 const dataToSend = {
                     documentId: currentDocumentId,
@@ -1439,7 +1481,7 @@
                     canvasY: signatureToProcess.y,
                     canvasWidth: signatureToProcess.width,
                     canvasHeight: signatureToProcess.height,
-                    renderScale: Number(scale), // <-- ADICIONE ESTA LINHA!
+                    renderScale: Number(currentRenderScale), // Usa a escala dinâmica calculada
                     signaturePage: signatureToProcess.pageNum,
                     userCPF: userCPF,
                     signatureImage: signatureToProcess.content // O Base64 da imagem ou texto


### PR DESCRIPTION
Fixes PDF signature positioning by correcting backend coordinate calculation and improves mobile user experience.

Previously, the backend was multiplying frontend canvas coordinates by the render scale, causing signatures to be misplaced. This PR changes the operation to division, ensuring accurate placement. Additionally, it introduces an adaptive rendering scale and mobile-specific CSS adjustments to enhance usability on smaller screens.